### PR TITLE
Geojson generation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=['django-mptt==0.7.0'],
+    install_requires=['django-mptt==0.8.7'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',

--- a/simple_locations/forms.py
+++ b/simple_locations/forms.py
@@ -10,7 +10,7 @@ from django.forms.widgets import Widget, Select
 from simple_locations.models import Area,AreaType
 from django.conf import settings
 from mptt.forms import TreeNodeChoiceField
-from django.forms.util import ErrorList
+from django.forms.utils import ErrorList
 from code_generator.code_generator import generate_tracking_tag
 
 class LocationForm(forms.Form):

--- a/simple_locations/json_urls.py
+++ b/simple_locations/json_urls.py
@@ -1,0 +1,10 @@
+from django.conf.urls import url
+# Return geoJSON representations of data
+
+from . import json_views
+
+
+urlpatterns = [
+    url(r'^area/(?P<area_id>[0-9]+)/$', json_views.area, name='area'),
+    url(r'^area/(?P<area_id>[0-9]+)/children/$', json_views.children, name='children'),
+]

--- a/simple_locations/json_views.py
+++ b/simple_locations/json_views.py
@@ -1,0 +1,13 @@
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404
+from django.utils.safestring import mark_safe
+from django.http import JsonResponse
+import json
+
+from .models import Area
+
+def area(request, area_id):
+    return JsonResponse(Area.geojson(area_id))
+
+def children(request, area_id):
+    return JsonResponse(Area.geojson(area_id, children=True))


### PR DESCRIPTION
Adds endpoints to efficiently return geoJSON data for areas, intended for consumption by the location-map riot tag in openly.
