### PR TITLE
Fix admin autocomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+##simple_locations
+
+The common location package used for catalpa's projects. A hierarchical tree of geographical locations supporting location type and GIS data
+
+####Changelog
+
+  * Version 2.7.2
+    - optionally use django_extensions' ForeignKeyAutocompleteAdmin in admin interface
+
 #### Uploading a new version to PyPi
 
 * install setuptools and twine

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-##simple_locations
+## simple_locations
 
 The common location package used for catalpa's projects. A hierarchical tree of geographical locations supporting location type and GIS data
 
-####Changelog
+#### Changelog
 
   * Version 2.7.2
     - optionally use django_extensions' ForeignKeyAutocompleteAdmin in admin interface

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='simple_locations',
-    version='2.7.1',
+    version='2.7.2',
     license="BSD",
 
     description="The common location package used for catalpa's projects.",

--- a/simple_locations/admin.py
+++ b/simple_locations/admin.py
@@ -9,6 +9,15 @@ from mptt.admin import MPTTModelAdmin
 
 from simple_locations.models import Point, AreaType, Area
 
+try:
+    # optionally use django_extensions' ForeignKeyAutocompleteAdmin if available
+    from django_extensions.admin import ForeignKeyAutocompleteAdmin
+    class MPTTModelAutocompleteAdmin(MPTTModelAdmin, ForeignKeyAutocompleteAdmin):
+        pass
+except ImportError:
+    class MPTTModelAutocompleteAdmin(MPTTModelAdmin):
+        pass
+
 
 class PointAdmin(admin.ModelAdmin):
     list_display = ('id', 'latitude', 'longitude')
@@ -18,11 +27,12 @@ class AreaTypeAdmin(admin.ModelAdmin):
     list_display = ('slug', 'name')
 
 
-class AreaAdmin(MPTTModelAdmin):
+class AreaAdmin(MPTTModelAutocompleteAdmin):
     list_display = ( 'name', 'kind', 'location', 'code')
     search_fields = ['code', 'name']
     list_filter = ('kind',)
-    
+    related_search_fields = {'parent': ('^name',)}
+
 
 admin.site.register(Point, PointAdmin)
 admin.site.register(AreaType, AreaTypeAdmin)


### PR DESCRIPTION
This change uses django_extensions' autocomplete if the package is available (it's default on our servers but this is a public package). If available the `parent` field has autocompletion and a popup selection window search icon.

The main requirement for this is to enable `health_facility` admin interface to have autocompletion on simple_locations `Area` models (instead of displaying a full admin page HTML code in the field...)

To be replaced with Django's native solution for Django>=2.0