### PR TITLE
compatibility with Django 5.0, Python 3.12 and Pydantic 2.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,21 +35,21 @@ homepage = "https://github.com/catalpainternational/simple_locations"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-mptt = "^0.14.0"
+django-mptt = "^0.16.0"
 pydantic = ">=1.10, <3"
 django-ninja = ">=0.21, <2"
-django-geojson = "^4.0.0"
+django-geojson = "^4.1.0"
 
 [tool.poetry.group.dev]
 optional = true
 
 [tool.poetry.group.dev.dependencies]
-black = {extras = ["jupyter"], version = "^23.1.0"}
+black = { extras = ["jupyter"], version = "^23.1.0" }
 flake8 = "*"
 isort = "*"
 pre-commit = "*"
 mypy = "*"
-django-stubs = {extras = ["compatible-mypy"], version = "^1.16.0"}
+django-stubs = { extras = ["compatible-mypy"], version = "^1.16.0" }
 psycopg2-binary = "*"
 pytest-django = "*"
 pytest-cov = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ homepage = "https://github.com/catalpainternational/simple_locations"
 [tool.poetry.dependencies]
 python = "^3.8"
 django-mptt = "^0.14.0"
-pydantic = "^1.10.6"
-django-ninja = "^0.21.0"
+pydantic = ">=1.10, <3"
+django-ninja = ">=0.21, <2"
 django-geojson = "^4.0.0"
 
 [tool.poetry.group.dev]

--- a/simple_locations/feature_manager.py
+++ b/simple_locations/feature_manager.py
@@ -31,7 +31,7 @@ class FeatureQueryset(models.QuerySet):
         >>> # A FeatureCollection:
         >>> FeatureCollection.parse_obj(queryset.aggregate(features = JSONBAgg(JsonFeature())))
         """
-        return FeatureCollection.construct(features=[*self.to_features(simplify=simplify, quantize=quantize)])
+        return FeatureCollection.model_construct(features=[*self.to_features(simplify=simplify, quantize=quantize)])
 
     def annotate_features(self, simplify: Union[float, None] = None, quantize: Union[int, None] = None):
         """

--- a/simple_locations/model_schemas.py
+++ b/simple_locations/model_schemas.py
@@ -4,12 +4,12 @@ from simple_locations.models import Area, AreaType
 
 
 class AreaModelSchema(ModelSchema):
-    class Config:
+    class Meta:
         model = Area
-        model_fields = ["name", "id", "kind", "parent"]
+        fields = ["name", "id", "kind", "parent"]
 
 
 class AreaTypeModelSchema(ModelSchema):
-    class Config:
+    class Meta:
         model = AreaType
-        model_fields = ["id", "name", "slug"]
+        fields = ["id", "name", "slug"]


### PR DESCRIPTION
A few updates to make simple_locations compatible with Django 5.0, Python 3.12 and Pydantic 2.x
To be merged in the existing sl_dird branch (unless changes are useful for other projects too, of course)