### PR TITLE
Optional support for Django Guardian permissions on Area admin

### DIFF
--- a/simple_locations/admin.py
+++ b/simple_locations/admin.py
@@ -16,6 +16,16 @@ except ImportError:
     TranslationAdmin = admin.ModelAdmin
     pass
 
+# Optionally support Django Guardian per-object permissions in Area
+try:
+    from guardian.admin import GuardedModelAdminMixin
+
+    area_admin_classes.insert(0, GuardedModelAdminMixin)
+except ImportError:
+    pass
+
+print(area_admin_classes)
+
 
 class PointAdmin(admin.ModelAdmin):
     list_display = ("id", "latitude", "longitude")

--- a/simple_locations/admin.py
+++ b/simple_locations/admin.py
@@ -24,8 +24,6 @@ try:
 except ImportError:
     pass
 
-print(area_admin_classes)
-
 
 class PointAdmin(admin.ModelAdmin):
     list_display = ("id", "latitude", "longitude")


### PR DESCRIPTION
## Description
Simple conditional import that, if available, adds Django Guardian Admin Mixin to Area, to allow editing per-Area permissions for users and group from the Django Admin