### PR TITLE
replace not nodes|length_is 0 with nodes|length > 0

### DIFF
--- a/simple_locations/templates/simple_locations/location_edit.html
+++ b/simple_locations/templates/simple_locations/location_edit.html
@@ -53,7 +53,7 @@
                 <td>{{form.kind}}</td>
                 <td class="errors">{{form.kind.errors}}</td>
             </tr>
-            {% if not nodes|length_is:"0" %}
+            {% if nodes|length > 0 %}
             <tr>
                 <td>{{ form.move_choice }}Move:
                 <td>{{ form.position }} &nbsp;&nbsp;&nbsp;Of:{{ form.target }}</td>


### PR DESCRIPTION
## Description
Django 5.1 removed the `length_is` template filter, replacing it with equivalent code.
I use the same code to do something if we have more than 8 articles in the Bilum knowledge base so the code should work, but I'd very much appreciate a way to actually test it, do we have an example application to test simple_locations? :sweat_smile: 