### PR TITLE
Fix DEFAULT_AUTO_FIELD drift (declare AppConfig with AutoField)

### DIFF
--- a/simple_locations/apps.py
+++ b/simple_locations/apps.py
@@ -1,0 +1,22 @@
+from django.apps import AppConfig
+
+
+class SimpleLocationsConfig(AppConfig):
+    """AppConfig for ``simple_locations``.
+
+    Pins ``default_auto_field`` to ``AutoField`` so the app does not inherit a
+    consuming project's ``DEFAULT_AUTO_FIELD``. Every model in this app was
+    created with an integer ``AutoField`` primary key (see migrations
+    ``0001``-onwards). Without this, a project that sets
+    ``DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"`` (the default for
+    ``startproject`` since Django 3.2) makes ``makemigrations`` perpetually want
+    to emit an ``alter *_id`` migration for this installed package — noise the
+    consumer cannot commit.
+
+    This is intentionally ``AutoField`` (not ``BigAutoField``): it matches the
+    existing migration history, so it is a metadata-only change with no schema
+    migration for any existing consumer's data.
+    """
+
+    name = "simple_locations"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
## Problem

`simple_locations` ships **no `AppConfig`**, so it inherits the consuming
project's `DEFAULT_AUTO_FIELD`. Every model here was created with an integer
`AutoField` primary key (migrations `0001`-onwards), so any project that sets
`DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"` — the `startproject`
default since Django 3.2 — makes `makemigrations` **perpetually want to write an
`alter *_id` migration for this installed package**, into the consumer's
`site-packages`/`.venv`. That is noise the consumer can never commit, and it
breaks any `makemigrations --check` CI gate on their side.

Surfaced downstream in catalpainternational/partisipa-import.

## Fix (this PR — one file)

Add `simple_locations/apps.py` declaring
`default_auto_field = "django.db.models.AutoField"` (auto-discovered on Django
3.2+). Deliberately **`AutoField`, not `BigAutoField`**: it matches the existing
migration history, so it is a **metadata-only change — no schema migration** for
any existing consumer (every `id` is already `int4`).

Verified by identical mechanism downstream: applying the same AppConfig to a
copy of this app under a `BigAutoField` project turned `makemigrations` from
"wants to alter every `*_id`" to clean.

## Heads-up: CI on `dev` is pre-existing-broken (not caused by this PR)

The red checks here are **not** from this one-file change — the pipeline can't
run on `dev` today, for two independent reasons:

1. **Python 3.8 is EOL.** The workflow pins `python-version: "3.8"`, and the
   current `virtualenv` seeder no longer ships pip/setuptools for 3.8, so
   `poetry install` fails to build the venv.
2. **`python`/`django-mptt` constraints conflict.** `pyproject.toml` declares
   `python = "^3.8"` while `django-mptt = "^0.16.0"` requires Python ≥ 3.9, so
   `poetry lock`/`poetry install` cannot resolve at all.

Suggested separate maintenance pass (kept out of this fix to stay minimal):
bump `python = "^3.9"` (or higher), bump the CI `python-version` to 3.11,
regenerate `poetry.lock`, then add a `makemigrations --check` CI step —
`tests/test_settings.py` already pins `BigAutoField`, so that step reproduces
this exact drift and would guard against recurrence.

## Downstream follow-up

Once released, partisipa replaces a temporary vendoring workaround with a bump
back to this (fixed) pip dependency. Version bump intentionally left to you.
