### PR TITLE
ci: publish to PyPI on release (API token)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,66 @@
+name: Publish to PyPI
+
+# Publishes the package to PyPI via OIDC "Trusted Publishing" — no API token or
+# password is stored in the repo. The trusted publisher must be configured once
+# on PyPI (project → Settings → Publishing) to match this repo, this workflow
+# filename (publish.yml) and the `pypi` environment used below.
+#
+# Release flow:
+#   1. Set the version in pyproject.toml and commit it.
+#   2. Create a GitHub Release whose tag matches that version (e.g. v4.1.0b2).
+#   3. Publishing it triggers this workflow.
+
+on:
+  release:
+    types: [published]
+  # Manual trigger for dry runs / re-publishing a build if needed.
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  build:
+    name: Build sdist + wheel
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Build
+        run: poetry build
+
+      - name: Show built artifacts
+        run: ls -l dist/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    # Match this to the environment named in the PyPI trusted-publisher config.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/simple-locations
+    permissions:
+      # Required for OIDC — this is what lets PyPI trust the workflow with no
+      # token. Kept minimal (this job needs nothing else).
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (OIDC trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,14 @@
 name: Publish to PyPI
 
-# Publishes the package to PyPI via OIDC "Trusted Publishing" — no API token or
-# password is stored in the repo. The trusted publisher must be configured once
-# on PyPI (project → Settings → Publishing) to match this repo, this workflow
-# filename (publish.yml) and the `pypi` environment used below.
+# Publishes the package to PyPI on a published GitHub Release, authenticating
+# with a PyPI API token stored as the `PYPI_API_TOKEN` GitHub Actions secret.
+#
+# One-time setup:
+#   1. On PyPI: Account settings → API tokens → "Add API token", scoped to the
+#      `simple-locations` project. Copy the token (starts with `pypi-`).
+#   2. In this repo: Settings → Secrets and variables → Actions → New repository
+#      secret, name `PYPI_API_TOKEN`, value = the token.
+#      (or: `gh secret set PYPI_API_TOKEN --repo catalpainternational/simple_locations`)
 #
 # Release flow:
 #   1. Set the version in pyproject.toml and commit it.
@@ -13,14 +18,14 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
-  # Manual trigger for dry runs / re-publishing a build if needed.
+  # Manual trigger for re-publishing a build if needed.
   workflow_dispatch:
 
 permissions: {}
 
 jobs:
-  build:
-    name: Build sdist + wheel
+  publish:
+    name: Build and publish to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,35 +37,10 @@ jobs:
       - name: Install poetry
         run: pipx install poetry
 
-      - name: Build
+      - name: Build sdist + wheel
         run: poetry build
 
-      - name: Show built artifacts
-        run: ls -l dist/
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
-          if-no-files-found: error
-
-  publish:
-    name: Publish to PyPI
-    needs: build
-    runs-on: ubuntu-latest
-    # Match this to the environment named in the PyPI trusted-publisher config.
-    environment:
-      name: pypi
-      url: https://pypi.org/p/simple-locations
-    permissions:
-      # Required for OIDC — this is what lets PyPI trust the workflow with no
-      # token. Kept minimal (this job needs nothing else).
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to PyPI (OIDC trusted publishing)
+      - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/publish.yml` — publishes the package to PyPI on a
published GitHub Release, using a **PyPI API token** (GitHub secret
`PYPI_API_TOKEN`).

> Switched from OIDC trusted publishing to a token because trusted-publisher
> setup requires the PyPI project **Owner** role; a token only needs
> **Maintainer** (upload) rights.

## One-time setup (Maintainer can do this)

1. **PyPI** → Account settings → **API tokens** → *Add API token*, **scoped to
   the `simple-locations` project**. Copy the value (starts with `pypi-`).
2. **This repo** → Settings → Secrets and variables → Actions → *New repository
   secret*: name `PYPI_API_TOKEN`, value = the token. Or:
   ```sh
   gh secret set PYPI_API_TOKEN --repo catalpainternational/simple_locations
   ```

## Releasing

1. Set `version` in `pyproject.toml` and commit (e.g. `4.1.0b2`).
2. Create a GitHub Release with a matching tag.
3. Publishing it triggers the workflow → `poetry build` →
   `pypa/gh-action-pypi-publish` → PyPI.

Verified `poetry build` produces the sdist + wheel locally. Merge **#52** (fix +
green CI) first so the released code carries the auto-field fix.
