### PR TITLE
Declare AppConfig (default_auto_field=AutoField) — 4.0.2 (pydantic-1 line)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = '''
 
 [tool.poetry]
 name = "simple-locations"
-version = "4.0.1"
+version = "4.0.2"
 description = "The common location package for Catalpa's projects"
 authors = [
   "Joshua Brooks <josh@catalpa.io>",

--- a/simple_locations/apps.py
+++ b/simple_locations/apps.py
@@ -1,0 +1,22 @@
+from django.apps import AppConfig
+
+
+class SimpleLocationsConfig(AppConfig):
+    """AppConfig for ``simple_locations``.
+
+    Pins ``default_auto_field`` to ``AutoField`` so the app does not inherit a
+    consuming project's ``DEFAULT_AUTO_FIELD``. Every model in this app was
+    created with an integer ``AutoField`` primary key (see migrations
+    ``0001``-onwards). Without this, a project that sets
+    ``DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"`` (the default for
+    ``startproject`` since Django 3.2) makes ``makemigrations`` perpetually want
+    to emit an ``alter *_id`` migration for this installed package — noise the
+    consumer cannot commit.
+
+    This is intentionally ``AutoField`` (not ``BigAutoField``): it matches the
+    existing migration history, so it is a metadata-only change with no schema
+    migration for any existing consumer's data.
+    """
+
+    name = "simple_locations"
+    default_auto_field = "django.db.models.AutoField"


### PR DESCRIPTION
Backports the `default_auto_field = AutoField` fix (see #52) to the **pydantic-1 / django-ninja-0** `4.0.x` line, which downstream consumers still on django-ninja <1 (e.g. partisipa) can actually adopt — unlike 4.1.x, which requires pydantic 2 / django-ninja 1.

- Adds `simple_locations/apps.py` (metadata-only; matches existing migrations, no schema change).
- Bumps version 4.0.1 → 4.0.2.
- Verified `poetry build` produces the sdist + wheel.

Merge, then a `v4.0.2` release publishes it via the existing publish workflow.